### PR TITLE
drop pyfixest dependency

### DIFF
--- a/duckreg/duckreg.py
+++ b/duckreg/duckreg.py
@@ -40,15 +40,10 @@ class DuckReg(ABC):
         pass
 
     @abstractmethod
-    def estimate_feols(self):
-        pass
-
-    @abstractmethod
     def bootstrap(self):
         pass
 
     def fit(self):
-
         self.prepare_data()
         self.compress_data()
 

--- a/notebooks/introduction.ipynb
+++ b/notebooks/introduction.ipynb
@@ -13,88 +13,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <div id=\"Z8ojoZ\"></div>\n",
-       "            <script type=\"text/javascript\" data-lets-plot-script=\"library\">\n",
-       "                if(!window.letsPlotCallQueue) {\n",
-       "                    window.letsPlotCallQueue = [];\n",
-       "                }; \n",
-       "                window.letsPlotCall = function(f) {\n",
-       "                    window.letsPlotCallQueue.push(f);\n",
-       "                };\n",
-       "                (function() {\n",
-       "                    var script = document.createElement(\"script\");\n",
-       "                    script.type = \"text/javascript\";\n",
-       "                    script.src = \"https://cdn.jsdelivr.net/gh/JetBrains/lets-plot@v4.3.3/js-package/distr/lets-plot.min.js\";\n",
-       "                    script.onload = function() {\n",
-       "                        window.letsPlotCall = function(f) {f();};\n",
-       "                        window.letsPlotCallQueue.forEach(function(f) {f();});\n",
-       "                        window.letsPlotCallQueue = [];\n",
-       "                        \n",
-       "                    };\n",
-       "                    script.onerror = function(event) {\n",
-       "                        window.letsPlotCall = function(f) {};    // noop\n",
-       "                        window.letsPlotCallQueue = [];\n",
-       "                        var div = document.createElement(\"div\");\n",
-       "                        div.style.color = 'darkred';\n",
-       "                        div.textContent = 'Error loading Lets-Plot JS';\n",
-       "                        document.getElementById(\"Z8ojoZ\").appendChild(div);\n",
-       "                    };\n",
-       "                    var e = document.getElementById(\"Z8ojoZ\");\n",
-       "                    e.appendChild(script);\n",
-       "                })()\n",
-       "            </script>\n",
-       "            "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "            <div id=\"H4o5ME\"></div>\n",
-       "            <script type=\"text/javascript\" data-lets-plot-script=\"library\">\n",
-       "                if(!window.letsPlotCallQueue) {\n",
-       "                    window.letsPlotCallQueue = [];\n",
-       "                }; \n",
-       "                window.letsPlotCall = function(f) {\n",
-       "                    window.letsPlotCallQueue.push(f);\n",
-       "                };\n",
-       "                (function() {\n",
-       "                    var script = document.createElement(\"script\");\n",
-       "                    script.type = \"text/javascript\";\n",
-       "                    script.src = \"https://cdn.jsdelivr.net/gh/JetBrains/lets-plot@v4.3.3/js-package/distr/lets-plot.min.js\";\n",
-       "                    script.onload = function() {\n",
-       "                        window.letsPlotCall = function(f) {f();};\n",
-       "                        window.letsPlotCallQueue.forEach(function(f) {f();});\n",
-       "                        window.letsPlotCallQueue = [];\n",
-       "                        \n",
-       "                    };\n",
-       "                    script.onerror = function(event) {\n",
-       "                        window.letsPlotCall = function(f) {};    // noop\n",
-       "                        window.letsPlotCallQueue = [];\n",
-       "                        var div = document.createElement(\"div\");\n",
-       "                        div.style.color = 'darkred';\n",
-       "                        div.textContent = 'Error loading Lets-Plot JS';\n",
-       "                        document.getElementById(\"H4o5ME\").appendChild(div);\n",
-       "                    };\n",
-       "                    var e = document.getElementById(\"H4o5ME\");\n",
-       "                    e.appendChild(script);\n",
-       "                })()\n",
-       "            </script>\n",
-       "            "
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -325,52 +244,52 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>0.0</td>\n",
        "      <td>4.0</td>\n",
-       "      <td>12431</td>\n",
-       "      <td>99421.673390</td>\n",
-       "      <td>8.079221e+05</td>\n",
-       "      <td>7.997882</td>\n",
+       "      <td>14.0</td>\n",
+       "      <td>12578</td>\n",
+       "      <td>402400.659158</td>\n",
+       "      <td>1.288629e+07</td>\n",
+       "      <td>31.992420</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.0</td>\n",
-       "      <td>16.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9.0</td>\n",
        "      <td>13.0</td>\n",
-       "      <td>12339</td>\n",
-       "      <td>518280.624612</td>\n",
-       "      <td>2.178205e+07</td>\n",
-       "      <td>42.003454</td>\n",
+       "      <td>12148</td>\n",
+       "      <td>437349.340322</td>\n",
+       "      <td>1.575723e+07</td>\n",
+       "      <td>36.001757</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>12527</td>\n",
-       "      <td>213034.828735</td>\n",
-       "      <td>3.635397e+06</td>\n",
-       "      <td>17.006053</td>\n",
+       "      <td>13.0</td>\n",
+       "      <td>16.0</td>\n",
+       "      <td>12278</td>\n",
+       "      <td>552594.317837</td>\n",
+       "      <td>2.488290e+07</td>\n",
+       "      <td>45.006867</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>1.0</td>\n",
-       "      <td>0.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>12572</td>\n",
-       "      <td>389667.970245</td>\n",
-       "      <td>1.209021e+07</td>\n",
-       "      <td>30.994907</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>10.0</td>\n",
+       "      <td>12485</td>\n",
+       "      <td>387167.687624</td>\n",
+       "      <td>1.201895e+07</td>\n",
+       "      <td>31.010628</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>3.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>4.0</td>\n",
-       "      <td>14.0</td>\n",
-       "      <td>12500</td>\n",
-       "      <td>412476.473407</td>\n",
-       "      <td>1.362330e+07</td>\n",
-       "      <td>32.998118</td>\n",
+       "      <td>12534</td>\n",
+       "      <td>62578.495184</td>\n",
+       "      <td>3.249671e+05</td>\n",
+       "      <td>4.992699</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -378,11 +297,11 @@
       ],
       "text/plain": [
        "     D    f1    f2  count          sum_Y      sum_Y_sq     mean_Y\n",
-       "0  0.0   0.0   4.0  12431   99421.673390  8.079221e+05   7.997882\n",
-       "1  0.0  16.0  13.0  12339  518280.624612  2.178205e+07  42.003454\n",
-       "2  0.0  15.0   1.0  12527  213034.828735  3.635397e+06  17.006053\n",
-       "3  1.0   0.0  15.0  12572  389667.970245  1.209021e+07  30.994907\n",
-       "4  1.0   4.0  14.0  12500  412476.473407  1.362330e+07  32.998118"
+       "0  0.0   4.0  14.0  12578  402400.659158  1.288629e+07  31.992420\n",
+       "1  1.0   9.0  13.0  12148  437349.340322  1.575723e+07  36.001757\n",
+       "2  0.0  13.0  16.0  12278  552594.317837  2.488290e+07  45.006867\n",
+       "3  1.0  10.0  10.0  12485  387167.687624  1.201895e+07  31.010628\n",
+       "4  0.0   3.0   1.0  12534   62578.495184  3.249671e+05   4.992699"
       ]
      },
      "execution_count": 5,
@@ -403,7 +322,7 @@
     "compressed_df = conn.execute(q).fetchdf()\n",
     "conn.close()\n",
     "\n",
-    "compressed_df.eval(f\"mean_Y = sum_Y / count\", inplace=True)\n",
+    "compressed_df.eval(\"mean_Y = sum_Y / count\", inplace=True)\n",
     "print(compressed_df.shape)\n",
     "compressed_df.head()"
    ]
@@ -444,8 +363,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.06 s, sys: 180 ms, total: 1.24 s\n",
-      "Wall time: 135 ms\n"
+      "CPU times: user 1.77 s, sys: 85.8 ms, total: 1.86 s\n",
+      "Wall time: 330 ms\n"
      ]
     },
     {
@@ -514,8 +433,8 @@
    "source": [
     "%%time\n",
     "m = DuckRegression(\n",
-    "    db_name='large_dataset.db',\n",
-    "    table_name='data',\n",
+    "    db_name=\"large_dataset.db\",\n",
+    "    table_name=\"data\",\n",
     "    formula=\"Y ~ D + f1 + f2\",\n",
     "    cluster_col=\"\",\n",
     "    n_bootstraps=0,\n",
@@ -547,8 +466,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.8 s, sys: 593 ms, total: 9.4 s\n",
-      "Wall time: 4.11 s\n"
+      "CPU times: user 9.62 s, sys: 891 ms, total: 10.5 s\n",
+      "Wall time: 6.7 s\n"
      ]
     },
     {
@@ -594,7 +513,7 @@
        "      <th>D</th>\n",
        "      <td>0.999347</td>\n",
        "      <td>0.000632</td>\n",
-       "      <td>1580.197207</td>\n",
+       "      <td>1580.194126</td>\n",
        "      <td>0.0</td>\n",
        "      <td>0.998107</td>\n",
        "      <td>1.000586</td>\n",
@@ -606,7 +525,7 @@
       "text/plain": [
        "             Estimate  Std. Error      t value  Pr(>|t|)      2.5%     97.5%\n",
        "Coefficient                                                                 \n",
-       "D            0.999347    0.000632  1580.197207       0.0  0.998107  1.000586"
+       "D            0.999347    0.000632  1580.194126       0.0  0.998107  1.000586"
       ]
      },
      "execution_count": 7,
@@ -616,7 +535,7 @@
    ],
    "source": [
     "%%time\n",
-    "m_pf = pf.feols(\"Y ~ D | f1 + f2\", df, vcov = \"hetero\")\n",
+    "m_pf = pf.feols(\"Y ~ D | f1 + f2\", df, vcov=\"hetero\")\n",
     "m_pf.tidy()"
    ]
   },
@@ -629,24 +548,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4min 3s, sys: 6.9 s, total: 4min 10s\n",
-      "Wall time: 1min\n"
+      "CPU times: user 5min 21s, sys: 10.2 s, total: 5min 31s\n",
+      "Wall time: 2min 8s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(np.float64(0.9993468884183836), np.float64(0.0006324203286037651))"
+       "(np.float64(0.9993468884184155), np.float64(0.0006324203286037653))"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -676,14 +595,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 12.99it/s]\n"
+      "100%|██████████| 100/100 [00:31<00:00,  3.18it/s]\n"
      ]
     },
     {
@@ -744,19 +663,19 @@
        "3        2.000067        0.000037"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "m = DuckRegression(\n",
-    "    db_name='large_dataset.db',\n",
-    "    table_name='data',\n",
+    "    db_name=\"large_dataset.db\",\n",
+    "    table_name=\"data\",\n",
     "    formula=\"Y ~ D + f1 + f2\",\n",
     "    cluster_col=\"f1\",\n",
     "    n_bootstraps=100,\n",
-    "    seed = 42\n",
+    "    seed=42,\n",
     ")\n",
     "m.fit()\n",
     "results = m.summary()\n",
@@ -777,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -807,68 +726,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the `DuckRegression` class, you can choose to run the model fits via the `pyfixest` package, in which case \n",
-    "the `DuckRegression.fit()` will return a `pyfixest` model object and is therefore compatible with the `pyfixest` API (tables, visualisers etc)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 100/100 [00:07<00:00, 13.41it/s]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                     est1                    est2\n",
-      "------------  ---------------------------  ----------------------\n",
-      "depvar                             mean_Y                       Y\n",
-      "-----------------------------------------------------------------\n",
-      "Intercept     -0.000274*** (8e-06.000000)\n",
-      "D              0.999347*** (6e-06.000000)  0.999347*** (0.000941)\n",
-      "f1             1.000035*** (1e-06.000000)\n",
-      "f2             2.000067*** (1e-06.000000)\n",
-      "-----------------------------------------------------------------\n",
-      "f1                                      -                       x\n",
-      "f2                                      -                       x\n",
-      "-----------------------------------------------------------------\n",
-      "R2                                      -                0.994031\n",
-      "S.E. type                             iid                  by: f1\n",
-      "Observations                     10000000                10000000\n",
-      "-----------------------------------------------------------------\n",
-      "Significance levels: * p < 0.05, ** p < 0.01, *** p < 0.001\n",
-      "Format of coefficient cell:\n",
-      "Coefficient (Std. Error)\n"
-     ]
-    }
-   ],
-   "source": [
-    "m = DuckRegression(\n",
-    "    db_name='large_dataset.db',\n",
-    "    table_name='data',\n",
-    "    formula=\"Y ~ D + f1 + f2\",\n",
-    "    cluster_col=\"f1\",\n",
-    "    n_bootstraps=100,\n",
-    "    seed = 42,\n",
-    "    fitter = \"feols\"\n",
-    ")\n",
-    "duckreg_fit = m.fit()\n",
-    "\n",
-    "feols_fit = pf.feols(\"Y ~ D | f1 + f2\", data = df)\n",
-    "pf.etable([duckreg_fit, feols_fit], digits = 6)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### multiple outcomes"
    ]
   },
@@ -881,28 +738,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 100/100 [00:08<00:00, 12.35it/s]\n"
+      "100%|██████████| 100/100 [00:36<00:00,  2.75it/s]"
      ]
     },
     {
-     "data": {
-      "text/plain": [
-       "{'point_estimate': array([-2.73682294e-04, -4.39868205e-04,  9.99347122e-01, -9.99443294e-01,\n",
-       "         1.00003536e+00,  1.00006450e+00,  2.00006685e+00,  1.99995671e+00]),\n",
-       " 'standard_error': array([6.70325435e-04, 4.15857348e-04, 7.26599979e-04, 4.45407815e-04,\n",
-       "        4.67005434e-05, 4.95007891e-05, 3.96508809e-05, 3.66987192e-05])}"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'point_estimate': array([-2.73682294e-04, -4.39868205e-04,  9.99347122e-01, -9.99443294e-01,\n",
+      "        1.00003536e+00,  1.00006450e+00,  2.00006685e+00,  1.99995671e+00]), 'standard_error': array([6.70325435e-04, 4.15857348e-04, 7.26599979e-04, 4.45407815e-04,\n",
+      "       4.67005434e-05, 4.95007891e-05, 3.96508809e-05, 3.66987192e-05])}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
     }
    ],
    "source": [
@@ -928,7 +788,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -968,67 +828,67 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>1.0</td>\n",
-       "      <td>12.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>12727</td>\n",
-       "      <td>216544.840414</td>\n",
-       "      <td>190925.760161</td>\n",
-       "      <td>3.697190e+06</td>\n",
-       "      <td>2.876925e+06</td>\n",
-       "      <td>17.014602</td>\n",
-       "      <td>15.001631</td>\n",
+       "      <td>18.0</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>12245</td>\n",
+       "      <td>256922.466208</td>\n",
+       "      <td>232671.227573</td>\n",
+       "      <td>5.402821e+06</td>\n",
+       "      <td>4.433033e+06</td>\n",
+       "      <td>20.981827</td>\n",
+       "      <td>19.001325</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>15.0</td>\n",
+       "      <td>12.0</td>\n",
        "      <td>5.0</td>\n",
-       "      <td>12619</td>\n",
-       "      <td>315592.063979</td>\n",
-       "      <td>315659.678406</td>\n",
-       "      <td>7.905289e+06</td>\n",
-       "      <td>7.908705e+06</td>\n",
-       "      <td>25.009277</td>\n",
-       "      <td>25.014635</td>\n",
+       "      <td>12718</td>\n",
+       "      <td>279696.580301</td>\n",
+       "      <td>279678.541654</td>\n",
+       "      <td>6.163872e+06</td>\n",
+       "      <td>6.162988e+06</td>\n",
+       "      <td>21.992183</td>\n",
+       "      <td>21.990764</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>14.0</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>12586</td>\n",
-       "      <td>301966.689482</td>\n",
-       "      <td>302001.382204</td>\n",
-       "      <td>7.257325e+06</td>\n",
-       "      <td>7.259209e+06</td>\n",
-       "      <td>23.992268</td>\n",
-       "      <td>23.995025</td>\n",
+       "      <td>6.0</td>\n",
+       "      <td>2.0</td>\n",
+       "      <td>12469</td>\n",
+       "      <td>124708.589734</td>\n",
+       "      <td>124790.291861</td>\n",
+       "      <td>1.259666e+06</td>\n",
+       "      <td>1.261313e+06</td>\n",
+       "      <td>10.001491</td>\n",
+       "      <td>10.008043</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>11.0</td>\n",
-       "      <td>8.0</td>\n",
-       "      <td>12599</td>\n",
-       "      <td>340300.406938</td>\n",
-       "      <td>340113.795719</td>\n",
-       "      <td>9.204282e+06</td>\n",
-       "      <td>9.194163e+06</td>\n",
-       "      <td>27.010112</td>\n",
-       "      <td>26.995301</td>\n",
+       "      <td>15.0</td>\n",
+       "      <td>17.0</td>\n",
+       "      <td>12453</td>\n",
+       "      <td>610166.237666</td>\n",
+       "      <td>610165.908721</td>\n",
+       "      <td>2.990896e+07</td>\n",
+       "      <td>2.990910e+07</td>\n",
+       "      <td>48.997530</td>\n",
+       "      <td>48.997503</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>18.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>12452</td>\n",
-       "      <td>448405.221116</td>\n",
-       "      <td>448468.700029</td>\n",
-       "      <td>1.615983e+07</td>\n",
-       "      <td>1.616454e+07</td>\n",
-       "      <td>36.010699</td>\n",
-       "      <td>36.015797</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>12564</td>\n",
+       "      <td>452407.523390</td>\n",
+       "      <td>452339.476470</td>\n",
+       "      <td>1.630282e+07</td>\n",
+       "      <td>1.629817e+07</td>\n",
+       "      <td>36.008240</td>\n",
+       "      <td>36.002824</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -1046,67 +906,67 @@
        "    <tr>\n",
        "      <th>795</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>18.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>12308</td>\n",
-       "      <td>590645.689337</td>\n",
-       "      <td>590779.609323</td>\n",
-       "      <td>2.835667e+07</td>\n",
-       "      <td>2.836954e+07</td>\n",
-       "      <td>47.988763</td>\n",
-       "      <td>47.999643</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>12288</td>\n",
+       "      <td>429970.734569</td>\n",
+       "      <td>430185.648925</td>\n",
+       "      <td>1.505780e+07</td>\n",
+       "      <td>1.507252e+07</td>\n",
+       "      <td>34.991108</td>\n",
+       "      <td>35.008598</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>796</th>\n",
-       "      <td>1.0</td>\n",
-       "      <td>6.0</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>12651</td>\n",
-       "      <td>215127.852416</td>\n",
-       "      <td>189587.011183</td>\n",
-       "      <td>3.670741e+06</td>\n",
-       "      <td>2.853889e+06</td>\n",
-       "      <td>17.004810</td>\n",
-       "      <td>14.985931</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>12.0</td>\n",
+       "      <td>15.0</td>\n",
+       "      <td>12586</td>\n",
+       "      <td>528694.632656</td>\n",
+       "      <td>528781.945956</td>\n",
+       "      <td>2.222105e+07</td>\n",
+       "      <td>2.222837e+07</td>\n",
+       "      <td>42.006565</td>\n",
+       "      <td>42.013503</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>797</th>\n",
+       "      <td>0.0</td>\n",
+       "      <td>7.0</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>15.0</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>12464</td>\n",
-       "      <td>249416.510286</td>\n",
-       "      <td>224266.276987</td>\n",
-       "      <td>5.003233e+06</td>\n",
-       "      <td>4.047546e+06</td>\n",
-       "      <td>20.010952</td>\n",
-       "      <td>17.993122</td>\n",
+       "      <td>12553</td>\n",
+       "      <td>112911.540312</td>\n",
+       "      <td>113157.333957</td>\n",
+       "      <td>1.028027e+06</td>\n",
+       "      <td>1.032739e+06</td>\n",
+       "      <td>8.994785</td>\n",
+       "      <td>9.014366</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>798</th>\n",
-       "      <td>0.0</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>17.0</td>\n",
-       "      <td>12375</td>\n",
-       "      <td>457882.075324</td>\n",
-       "      <td>457804.089079</td>\n",
-       "      <td>1.695394e+07</td>\n",
-       "      <td>1.694838e+07</td>\n",
-       "      <td>37.000572</td>\n",
-       "      <td>36.994270</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>9.0</td>\n",
+       "      <td>5.0</td>\n",
+       "      <td>12485</td>\n",
+       "      <td>249685.048950</td>\n",
+       "      <td>224838.365280</td>\n",
+       "      <td>5.006164e+06</td>\n",
+       "      <td>4.061446e+06</td>\n",
+       "      <td>19.998802</td>\n",
+       "      <td>18.008680</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>799</th>\n",
        "      <td>1.0</td>\n",
-       "      <td>19.0</td>\n",
-       "      <td>9.0</td>\n",
-       "      <td>12576</td>\n",
-       "      <td>477940.222143</td>\n",
-       "      <td>452409.682472</td>\n",
-       "      <td>1.817623e+07</td>\n",
-       "      <td>1.628749e+07</td>\n",
-       "      <td>38.004153</td>\n",
-       "      <td>35.974052</td>\n",
+       "      <td>1.0</td>\n",
+       "      <td>18.0</td>\n",
+       "      <td>12384</td>\n",
+       "      <td>470532.691004</td>\n",
+       "      <td>445822.891389</td>\n",
+       "      <td>1.789052e+07</td>\n",
+       "      <td>1.606216e+07</td>\n",
+       "      <td>37.995211</td>\n",
+       "      <td>35.999910</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1115,35 +975,35 @@
       ],
       "text/plain": [
        "       D    f1    f2  count          sum_Y         sum_Y2      sum_Y_sq  \\\n",
-       "0    1.0  12.0   2.0  12727  216544.840414  190925.760161  3.697190e+06   \n",
-       "1    0.0  15.0   5.0  12619  315592.063979  315659.678406  7.905289e+06   \n",
-       "2    0.0  14.0   5.0  12586  301966.689482  302001.382204  7.257325e+06   \n",
-       "3    0.0  11.0   8.0  12599  340300.406938  340113.795719  9.204282e+06   \n",
-       "4    0.0  18.0   9.0  12452  448405.221116  448468.700029  1.615983e+07   \n",
+       "0    1.0  18.0   1.0  12245  256922.466208  232671.227573  5.402821e+06   \n",
+       "1    0.0  12.0   5.0  12718  279696.580301  279678.541654  6.163872e+06   \n",
+       "2    0.0   6.0   2.0  12469  124708.589734  124790.291861  1.259666e+06   \n",
+       "3    0.0  15.0  17.0  12453  610166.237666  610165.908721  2.990896e+07   \n",
+       "4    0.0  12.0  12.0  12564  452407.523390  452339.476470  1.630282e+07   \n",
        "..   ...   ...   ...    ...            ...            ...           ...   \n",
-       "795  0.0  18.0  15.0  12308  590645.689337  590779.609323  2.835667e+07   \n",
-       "796  1.0   6.0   5.0  12651  215127.852416  189587.011183  3.670741e+06   \n",
-       "797  1.0  15.0   2.0  12464  249416.510286  224266.276987  5.003233e+06   \n",
-       "798  0.0   3.0  17.0  12375  457882.075324  457804.089079  1.695394e+07   \n",
-       "799  1.0  19.0   9.0  12576  477940.222143  452409.682472  1.817623e+07   \n",
+       "795  0.0  11.0  12.0  12288  429970.734569  430185.648925  1.505780e+07   \n",
+       "796  0.0  12.0  15.0  12586  528694.632656  528781.945956  2.222105e+07   \n",
+       "797  0.0   7.0   1.0  12553  112911.540312  113157.333957  1.028027e+06   \n",
+       "798  1.0   9.0   5.0  12485  249685.048950  224838.365280  5.006164e+06   \n",
+       "799  1.0   1.0  18.0  12384  470532.691004  445822.891389  1.789052e+07   \n",
        "\n",
        "        sum_Y2_sq     mean_Y    mean_Y2  \n",
-       "0    2.876925e+06  17.014602  15.001631  \n",
-       "1    7.908705e+06  25.009277  25.014635  \n",
-       "2    7.259209e+06  23.992268  23.995025  \n",
-       "3    9.194163e+06  27.010112  26.995301  \n",
-       "4    1.616454e+07  36.010699  36.015797  \n",
+       "0    4.433033e+06  20.981827  19.001325  \n",
+       "1    6.162988e+06  21.992183  21.990764  \n",
+       "2    1.261313e+06  10.001491  10.008043  \n",
+       "3    2.990910e+07  48.997530  48.997503  \n",
+       "4    1.629817e+07  36.008240  36.002824  \n",
        "..            ...        ...        ...  \n",
-       "795  2.836954e+07  47.988763  47.999643  \n",
-       "796  2.853889e+06  17.004810  14.985931  \n",
-       "797  4.047546e+06  20.010952  17.993122  \n",
-       "798  1.694838e+07  37.000572  36.994270  \n",
-       "799  1.628749e+07  38.004153  35.974052  \n",
+       "795  1.507252e+07  34.991108  35.008598  \n",
+       "796  2.222837e+07  42.006565  42.013503  \n",
+       "797  1.032739e+06   8.994785   9.014366  \n",
+       "798  4.061446e+06  19.998802  18.008680  \n",
+       "799  1.606216e+07  37.995211  35.999910  \n",
        "\n",
        "[800 rows x 10 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1161,7 +1021,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -1246,7 +1106,7 @@
        "f2_Y2               1.999957        0.000037"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1271,7 +1131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1333,7 +1193,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1354,7 +1214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -1378,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,14 +1271,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "100%|██████████| 50/50 [00:52<00:00,  1.05s/it]\n"
+      "100%|██████████| 50/50 [01:37<00:00,  1.95s/it]\n"
      ]
     },
     {
@@ -1479,7 +1339,7 @@
        "3       -2.413955        0.002209"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1516,7 +1376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -1756,7 +1616,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "pyfixest-pKOwcWPT-py3.10",
+   "display_name": "metrics",
    "language": "python",
    "name": "python3"
   },
@@ -1770,7 +1630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pandas
 tqdm
 duckdb
 numba
-pyfixest
 pdoc

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read_long_description():
 
 setup(
     name="duckreg",
-    version="0.1.1",  # Use semantic versioning
+    version="0.2",  # Use semantic versioning
     packages=find_packages(),
     install_requires=read_requirements(),
     author="Apoorva Lal",


### PR DESCRIPTION
removes pyfixest as a default dependency, which makes the package substantially leaner and faster to install. Also fixes unit test failure on old python arising from pyfixest imports